### PR TITLE
Fix failing parsing

### DIFF
--- a/plugin.video.metalvideo/resources/lib/main.py
+++ b/plugin.video.metalvideo/resources/lib/main.py
@@ -105,7 +105,7 @@ def video_list(_, url, filter_mode=0):
         root_elem = resp.parse("div", attrs={"class": "col-md-12"})
         results = root_elem.iterfind("ul/li/div")
     elif filter_mode == 1:  # Related videos
-        root_elem = resp.parse("ul", attrs={"class": "pm-ul-sidelist-videos list-unstyled"})
+        root_elem = resp.parse("ul", attrs={"class": "pm-ul-browse-videos list-unstyled"})
         results = root_elem.iterfind("li")
     elif filter_mode == 2:  # Featured Videos
         root_elem = resp.parse("ul", attrs={"id": "pm-carousel_featured"})


### PR DESCRIPTION
The metal video site seems to have updated the class for related videos.
This fix makes the plugin v3.0.7 run again for me.
Can see that master version is 3.1.0, but not known to me what repo that is in.